### PR TITLE
Validate that the name and class query strings contain the same numbe…

### DIFF
--- a/include/entry.h
+++ b/include/entry.h
@@ -99,6 +99,12 @@ typedef struct xcb_xrm_entry_t {
 int xcb_xrm_entry_parse(const char *str, xcb_xrm_entry_t **entry, bool resource_only);
 
 /**
+ * Returns the number of components of the given entry.
+ *
+ */
+int xcb_xrm_entry_num_components(xcb_xrm_entry_t *entry);
+
+/**
  * Frees the given entry.
  *
  * @param entry The entry to be freed.

--- a/src/entry.c
+++ b/src/entry.c
@@ -245,6 +245,21 @@ done_error:
 }
 
 /*
+ * Returns the number of components of the given entry.
+ *
+ */
+int xcb_xrm_entry_num_components(xcb_xrm_entry_t *entry) {
+    int result = 0;
+
+    xcb_xrm_component_t *current;
+    TAILQ_FOREACH(current, &(entry->components), components) {
+        result++;
+    }
+
+    return result;
+}
+
+/*
  * Frees the given entry.
  *
  * @param entry The entry to be freed.

--- a/src/match.c
+++ b/src/match.c
@@ -52,13 +52,7 @@ int xcb_xrm_match(xcb_xrm_context_t *ctx, xcb_xrm_entry_t *query_name, xcb_xrm_e
     xcb_xrm_entry_t *cur_entry = TAILQ_FIRST(&(ctx->entries));
 
     /* Let's figure out how many elements we need to store. */
-    int num = 0;
-    do {
-        xcb_xrm_component_t *component;
-        TAILQ_FOREACH(component, &(query_name->components), components) {
-            num++;
-        }
-    } while (0);
+    int num = xcb_xrm_entry_num_components(query_name);
 
     while (cur_entry != NULL) {
         xcb_xrm_match_t *cur_match = __match_new(num);

--- a/src/xrm.c
+++ b/src/xrm.c
@@ -104,6 +104,15 @@ int xcb_xrm_resource_get(xcb_xrm_context_t *ctx, const char *res_name, const cha
         goto done;
     }
 
+    /* We rely on name and class query strings to have the same number of
+     * components, so let's check that this is the case. The specification
+     * backs us up here. */
+    if (query_class != NULL &&
+            xcb_xrm_entry_num_components(query_name) != xcb_xrm_entry_num_components(query_class)) {
+        result = -1;
+        goto done;
+    }
+
     result = xcb_xrm_match(ctx, query_name, query_class, resource);
 done:
     xcb_xrm_entry_free(query_name);

--- a/tests/test.c
+++ b/tests/test.c
@@ -243,6 +243,8 @@ static int test_get_resource(void) {
     err |= check_get_resource(ctx, "", "", NULL, NULL);
     err |= check_get_resource(ctx, "", NULL, NULL, NULL);
 
+    err |= check_get_resource(ctx, "Xft*dpi", "Xft.dpi", "Xft.toomuch.dpi", NULL);
+
     err |= check_get_resource(ctx, "", "Xft.dpi", "", NULL);
     err |= check_get_resource(ctx, "Xft.dpi: 96", "Xft.display", "", NULL);
     err |= check_get_resource(ctx, "Xft.dpi: 96", "Xft.dpi", "", "96");


### PR DESCRIPTION
…r of components.

The algorithm currently relies on name and class query string to consist
of the same number of components (if a class string is given).

fixes #7