### PR TITLE
Update parser and algorithms for spec-conform model.

### DIFF
--- a/include/entry.h
+++ b/include/entry.h
@@ -45,17 +45,23 @@ typedef enum {
 typedef enum {
     /* A "normal" component, i.e., a name/class is given. */
     CT_NORMAL = 0,
-    /* A single wildcard component ("?"). */
-    CT_WILDCARD_SINGLE = 1,
-    /* A multi wildcard component ("*"). */
-    CT_WILDCARD_MULTI = 2
+    /* A wildcard component ("?"). */
+    CT_WILDCARD = 1,
 } xcb_xrm_component_type_t;
+
+/** The binding type of a component. */
+typedef enum {
+    BT_TIGHT = 0,
+    BT_LOOSE = 1
+} xcb_xrm_binding_type_t;
 
 /** One component of a resource, either in the name or class. */
 typedef struct xcb_xrm_component_t {
     /* The type of this component. */
     xcb_xrm_component_type_t type;
-    /* This component's name. Only useful for CT_NORMAL. */
+    /* The binding type of this component. */
+    xcb_xrm_binding_type_t binding_type;
+    /* This component's name. Only useful if the type is CT_NORMAL. */
     char *name;
 
     TAILQ_ENTRY(xcb_xrm_component_t) components;
@@ -66,7 +72,7 @@ typedef struct xcb_xrm_entry_parser_state_t {
     xcb_xrm_entry_parser_chunk_status_t chunk;
     char buffer[4096];
     char *buffer_pos;
-    xcb_xrm_component_type_t current_type;
+    xcb_xrm_binding_type_t current_binding_type;
 } xcb_xrm_entry_parser_state_t;
 
 /**

--- a/include/match.h
+++ b/include/match.h
@@ -32,23 +32,29 @@
 #include "xrm.h"
 #include "entry.h"
 
-typedef enum xcb_xrm_match_type_t {
+/** Information about a matched component. */
+typedef enum xcb_xrm_match_flags_t {
     MT_NONE = 1 << 0,
 
-    MT_CLASS = 1 << 1,
-    MT_NAME = 1 << 2,
+    /* The component was matched on the name. */
+    MF_NAME = 1 << 1,
+    /* The component was matched on the class. */
+    MF_CLASS = 1 << 2,
+    /* The component was matched via a '?' wildcard. */
+    MF_WILDCARD = 1 << 3,
+    /* The component was matched as part of a loose binding. */
+    MF_SKIPPED = 1 << 4,
 
-    MT_EXACT = 1 << 3,
-    MT_SINGLE = 1 << 4,
-    MT_MULTI = 1 << 5
-} xcb_xrm_match_type_t;
+    /* This component was preceded by a loose binding. */
+    MF_PRECEDING_LOOSE = 1 << 5,
+} xcb_xrm_match_flags_t;
 
 typedef struct xcb_xrm_match_t {
     /* Reference to the database entry this match refers to. */
 	xcb_xrm_entry_t *entry;
     /* An array where the n-th element describes how the n-th element of the
      * query strings was matched. */
-	int *matches;
+	int *flags;
 } xcb_xrm_match_t;
 
 /**


### PR DESCRIPTION
This commit changes the model xcb-util-xrm uses to represent entries.
Previously, we considered both '?' and '*' (separate) components. However,
only '?' is actually a component on its own, while '*' is just a type of
binding between components (much like '.').

For example, this also means that while 'a*b' is correct, 'a?b' is not and
must rather be 'a.?.b' (or 'a*?.b' etc.).

Therefore, we clean up our internal model and correctly distinguish between
the binding type and a "normal" component versus a wildcard. This requires
both a change in the parser and in the algorithm implementation.

On top, this commit introduced proper validation of the characters used
in component names, conforming to the spec. Lastly, we clean up the tests
here and make them easier to read.