### PR TITLE
Reworked the entire API.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ xcbinclude_HEADERS = include/xcb_xrm.h
 
 AM_CFLAGS = $(CWARNFLAGS)
 
-libxcb_xrm_la_SOURCES = src/xrm.c src/entry.c src/util.c src/match.c
+libxcb_xrm_la_SOURCES = src/database.c src/resource.c src/entry.c src/match.c src/util.c
 libxcb_xrm_la_CPPFLAGS = -I$(srcdir)/include/ $(XCB_CFLAGS)
 libxcb_xrm_la_LIBADD = $(XCB_LIBS) -lm
 libxcb_xrm_la_LDFLAGS = -version-info 0:0:0 -no-undefined -export-symbols-regex '^xcb_xrm_'

--- a/include/database.h
+++ b/include/database.h
@@ -26,29 +26,14 @@
  * authorization from the authors.
  *
  */
-#ifndef __XRM_H__
-#define __XRM_H__
+#ifndef __DATABASE_H__
+#define __DATABASE_H__
 
-#include <sys/queue.h>
-#include <assert.h>
-#include <stdbool.h>
+#include "externals.h"
 
 #include "xcb_xrm.h"
-#include "util.h"
 #include "entry.h"
 
-struct xcb_xrm_context_t {
-    xcb_connection_t *conn;
-    xcb_screen_t *screen;
+TAILQ_HEAD(xcb_xrm_database_t, xcb_xrm_entry_t);
 
-    /* The unprocessed resource manager string. */
-    char *resources;
-
-    TAILQ_HEAD(database_head, xcb_xrm_entry_t) entries;
-};
-
-struct xcb_xrm_resource_t {
-    char *value;
-};
-
-#endif /* __XRM_H__ */
+#endif /* __DATABASE_H__ */

--- a/include/externals.h
+++ b/include/externals.h
@@ -26,34 +26,20 @@
  * authorization from the authors.
  *
  */
-#ifndef __UTIL_H__
-#define __UTIL_H__
+#ifndef __EXTERNALS_H__
+#define __EXTERNALS_H__
 
-#include "externals.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+#include <ctype.h>
+#include <err.h>
+#include <errno.h>
+#include <limits.h>
+#include <math.h>
+#include <sys/queue.h>
 
-#define FREE(p)          \
-    do {                 \
-        if (p != NULL) { \
-            free(p);     \
-            p = NULL;    \
-        }                \
-    } while (0)
+#include <xcb/xcb.h>
 
-#undef MAX
-#define MAX(x, y) ((x) > (y) ? (x) : (y))
-#undef MIN
-#define MIN(x, y) ((x) < (y) ? (x) : (y))
-
-#define SUCCESS 0
-#define FAILURE 1
-
-char *sstrdup(const char *str);
-
-void *scalloc(size_t num, size_t size);
-
-int str2int(int *out, char *input, int base);
-
-char *xcb_util_get_property(xcb_connection_t *conn, xcb_window_t window, xcb_atom_t atom,
-        xcb_atom_t type, size_t size);
-
-#endif /* __UTIL_H__ */
+#endif /* __EXTERNALS_H__ */

--- a/include/match.h
+++ b/include/match.h
@@ -29,7 +29,8 @@
 #ifndef __MATCH_H__
 #define __MATCH_H__
 
-#include "xrm.h"
+#include "database.h"
+#include "resource.h"
 #include "entry.h"
 
 /** Information about a matched component. */
@@ -61,7 +62,7 @@ typedef struct xcb_xrm_match_t {
  * Finds the matching entry in the database given a full name / class query string.
  *
  */
-int xcb_xrm_match(xcb_xrm_context_t *ctx, xcb_xrm_entry_t *query_name, xcb_xrm_entry_t *query_class,
+int xcb_xrm_match(xcb_xrm_database_t *database, xcb_xrm_entry_t *query_name, xcb_xrm_entry_t *query_class,
         xcb_xrm_resource_t *resource);
 
 #endif /* __MATCH_H__ */

--- a/include/resource.h
+++ b/include/resource.h
@@ -26,34 +26,17 @@
  * authorization from the authors.
  *
  */
-#ifndef __UTIL_H__
-#define __UTIL_H__
+#ifndef __RESOURCE_H__
+#define __RESOURCE_H__
 
 #include "externals.h"
 
-#define FREE(p)          \
-    do {                 \
-        if (p != NULL) { \
-            free(p);     \
-            p = NULL;    \
-        }                \
-    } while (0)
+#include "xcb_xrm.h"
+#include "util.h"
+#include "entry.h"
 
-#undef MAX
-#define MAX(x, y) ((x) > (y) ? (x) : (y))
-#undef MIN
-#define MIN(x, y) ((x) < (y) ? (x) : (y))
+struct xcb_xrm_resource_t {
+    char *value;
+};
 
-#define SUCCESS 0
-#define FAILURE 1
-
-char *sstrdup(const char *str);
-
-void *scalloc(size_t num, size_t size);
-
-int str2int(int *out, char *input, int base);
-
-char *xcb_util_get_property(xcb_connection_t *conn, xcb_window_t window, xcb_atom_t atom,
-        xcb_atom_t type, size_t size);
-
-#endif /* __UTIL_H__ */
+#endif /* __RESOURCE_H__ */

--- a/src/database.c
+++ b/src/database.c
@@ -1,0 +1,134 @@
+/*
+ * vim:ts=4:sw=4:expandtab
+ *
+ * Copyright © 2016 Ingo Bürk
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the names of the authors or their
+ * institutions shall not be used in advertising or otherwise to promote the
+ * sale, use or other dealings in this Software without prior written
+ * authorization from the authors.
+ *
+ */
+#include "externals.h"
+
+#include "database.h"
+#include "match.h"
+#include "util.h"
+
+/*
+ * Loads the RESOURCE_MANAGER property and creates a database with its
+ * contents. If the database could not be created, thie function will return
+ * NULL.
+ *
+ * @param conn A working XCB connection.
+ * @param screen The xcb_screen_t* screen to use.
+ * @returns The database described by the RESOURCE_MANAGER property.
+ *
+ * @ingroup xcb_xrm_database_t
+ */
+xcb_xrm_database_t *xcb_xrm_database_from_resource_manager(xcb_connection_t *conn, xcb_screen_t *screen) {
+    char *resources = xcb_util_get_property(conn, screen->root, XCB_ATOM_RESOURCE_MANAGER,
+            XCB_ATOM_STRING, 16 * 1024);
+    if (resources == NULL) {
+        return NULL;
+    }
+
+    /* Parse the resource string. */
+    return xcb_xrm_database_from_string(resources);
+}
+
+/*
+ * Creates a database from the given string.
+ * If the database could not be created, this function will return NULL.
+ *
+ * @param str The resource string.
+ * @returns The database described by the resource string.
+ *
+ * @ingroup xcb_xrm_database_t
+ */
+xcb_xrm_database_t *xcb_xrm_database_from_string(const char *_str) {
+    xcb_xrm_database_t *database;
+    char *str = sstrdup(_str);
+
+    int num_continuations = 0;
+    char *str_continued;
+    char *outwalk;
+
+    /* Count the number of line continuations. */
+    for (char *walk = str; *walk != '\0'; walk++) {
+        if (*walk == '\\' && *(walk + 1) == '\n') {
+            num_continuations++;
+        }
+    }
+
+    /* Take care of line continuations. */
+    str_continued = scalloc(1, strlen(str) + 1 - 2 * num_continuations);
+    outwalk = str_continued;
+    for (char *walk = str; *walk != '\0'; walk++) {
+        if (*walk == '\\' && *(walk + 1) == '\n') {
+            walk++;
+            continue;
+        }
+
+        *(outwalk++) = *walk;
+    }
+    *outwalk = '\0';
+
+    database = scalloc(1, sizeof(struct xcb_xrm_database_t));
+    TAILQ_INIT(database);
+
+    for (char *line = strtok(str_continued, "\n"); line != NULL; line = strtok(NULL, "\n")) {
+        xcb_xrm_entry_t *entry;
+
+        /* Ignore comments and directives. The specification guarantees that no
+         * whitespace is allowed before these characters. */
+        if (line[0] == '!' || line[0] == '#')
+            continue;
+
+        if (xcb_xrm_entry_parse(line, &entry, false) == 0 && entry != NULL) {
+            TAILQ_INSERT_TAIL(database, entry, entries);
+        }
+    }
+
+    FREE(str);
+    FREE(str_continued);
+    return database;
+}
+
+/**
+ * Destroys the given database.
+ *
+ * @param database The database to destroy.
+ *
+ * @ingroup xcb_xrm_database_t
+ */
+void xcb_xrm_database_free(xcb_xrm_database_t *database) {
+    xcb_xrm_entry_t *entry;
+    if (database == NULL)
+        return;
+
+    while (!TAILQ_EMPTY(database)) {
+        entry = TAILQ_FIRST(database);
+        TAILQ_REMOVE(database, entry, entries);
+        xcb_xrm_entry_free(entry);
+    }
+
+    FREE(database);
+}

--- a/src/entry.c
+++ b/src/entry.c
@@ -26,12 +26,7 @@
  * authorization from the authors.
  *
  */
-#include <stdlib.h>
-#include <stdbool.h>
-#include <string.h>
-#include <ctype.h>
-#include <errno.h>
-#include <sys/queue.h>
+#include "externals.h"
 
 #include "entry.h"
 #include "util.h"

--- a/src/match.c
+++ b/src/match.c
@@ -26,11 +26,7 @@
  * authorization from the authors.
  *
  */
-#include <stdlib.h>
-#include <stdbool.h>
-#include <string.h>
-#include <errno.h>
-#include <sys/queue.h>
+#include "externals.h"
 
 #include "match.h"
 #include "util.h"
@@ -46,10 +42,10 @@ static void __match_free(xcb_xrm_match_t *match);
  * Finds the matching entry in the database given a full name / class query string.
  *
  */
-int xcb_xrm_match(xcb_xrm_context_t *ctx, xcb_xrm_entry_t *query_name, xcb_xrm_entry_t *query_class,
+int xcb_xrm_match(xcb_xrm_database_t *database, xcb_xrm_entry_t *query_name, xcb_xrm_entry_t *query_class,
         xcb_xrm_resource_t *resource) {
     xcb_xrm_match_t *best_match = NULL;
-    xcb_xrm_entry_t *cur_entry = TAILQ_FIRST(&(ctx->entries));
+    xcb_xrm_entry_t *cur_entry = TAILQ_FIRST(database);
 
     /* Let's figure out how many elements we need to store. */
     int num = xcb_xrm_entry_num_components(query_name);

--- a/src/util.c
+++ b/src/util.c
@@ -26,15 +26,7 @@
  * authorization from the authors.
  *
  */
-#include <stdlib.h>
-#include <stdio.h>
-#include <stdbool.h>
-#include <string.h>
-#include <ctype.h>
-#include <err.h>
-#include <errno.h>
-#include <limits.h>
-#include <math.h>
+#include "externals.h"
 
 #include "util.h"
 


### PR DESCRIPTION
This commit changes the API from the ground up (of course, in a breaking
way). We don't actually have much of a reason to use a "context" since
most of what we do does not directly concern X (or xcb for that matter).
The only case where we need a X connection is when fetching the resource
manager content from the root window.

Therefore, we move from having a context object as the central concept of
this library to using the database struct for this. This is closer related
to how the Xlib equivalent works and will also allow a more straight-forward
API when introducing the APIs to combine / merge / manipulate databases.