### PR TITLE
Do not use err() in library.

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -52,6 +52,8 @@ int xcb_xrm_match(xcb_xrm_database_t *database, xcb_xrm_entry_t *query_name, xcb
 
     while (cur_entry != NULL) {
         xcb_xrm_match_t *cur_match = __match_new(num);
+        if (cur_match == NULL)
+            return -FAILURE;
 
         /* First we check whether the current database entry even matches. */
         if (__match_matches(cur_entry, query_name, query_class, cur_match) == 0) {
@@ -77,6 +79,8 @@ int xcb_xrm_match(xcb_xrm_database_t *database, xcb_xrm_entry_t *query_name, xcb
 
     if (best_match != NULL) {
         resource->value = sstrdup(best_match->entry->value);
+        if (resource->value == NULL)
+            return -FAILURE;
 
         __match_free(best_match);
         return SUCCESS;
@@ -187,8 +191,16 @@ static int __match_compare(int length, xcb_xrm_match_t *best, xcb_xrm_match_t *c
 
 static xcb_xrm_match_t *__match_new(int length) {
     xcb_xrm_match_t *match = scalloc(1, sizeof(struct xcb_xrm_match_t));
+    if (match == NULL)
+        return NULL;
+
     match->entry = NULL;
     match->flags = scalloc(1, length * sizeof(xcb_xrm_match_flags_t));
+    if (match->flags == NULL) {
+        FREE(match);
+        return NULL;
+    }
+
     return match;
 }
 

--- a/src/resource.c
+++ b/src/resource.c
@@ -51,18 +51,22 @@ int xcb_xrm_resource_get(xcb_xrm_database_t *database, const char *res_name, con
     xcb_xrm_resource_t *resource;
     xcb_xrm_entry_t *query_name = NULL;
     xcb_xrm_entry_t *query_class = NULL;
-    int result = 0;
+    int result = SUCCESS;
 
     if (database == NULL || TAILQ_EMPTY(database)) {
         *_resource = NULL;
-        return -1;
+        return -FAILURE;
     }
 
     *_resource = scalloc(1, sizeof(struct xcb_xrm_resource_t));
+    if (_resource == NULL) {
+        result = -FAILURE;
+        goto done;
+    }
     resource = *_resource;
 
     if (res_name == NULL || xcb_xrm_entry_parse(res_name, &query_name, true) < 0) {
-        result = -1;
+        result = -FAILURE;
         goto done;
     }
 

--- a/src/util.c
+++ b/src/util.c
@@ -31,21 +31,11 @@
 #include "util.h"
 
 char *sstrdup(const char *str) {
-    char *result = strdup(str);
-    if (result == NULL) {
-        err(-ENOMEM, "strdup() failed!");
-    }
-
-    return result;
+    return strdup(str);
 }
 
 void *scalloc(size_t num, size_t size) {
-    void *result = calloc(num, size);
-    if (result == NULL) {
-        err(-ENOMEM, "calloc(%zd, %zd) failed!", num, size);
-    }
-
-    return result;
+    return calloc(num, size);
 }
 
 int sasprintf(char **strp, const char *fmt, ...) {
@@ -53,8 +43,7 @@ int sasprintf(char **strp, const char *fmt, ...) {
     int result;
 
     va_start(args, fmt);
-    if ((result = vasprintf(strp, fmt, args)) == -1)
-        err(EXIT_FAILURE, "asprintf(%s)", fmt);
+    result = vasprintf(strp, fmt, args);
     va_end(args);
     return result;
 }
@@ -97,6 +86,11 @@ char *file_get_contents(const char *filename) {
 
     /* Read the file content. */
     content = scalloc(file_size, 1);
+    if (content == NULL) {
+        fclose(file);
+        return NULL;
+    }
+
     if (fread(content, 1, file_size, file) != file_size) {
         FREE(content);
         fclose(file);


### PR DESCRIPTION
We don't want to exit the application from within a library due to memory
allocation failures, so we instead try to fail gracefully.

fixes #30