### PR TITLE
Reference gethostname(2), not gethostname(3p)

### DIFF
--- a/include/xcb_xrm.h
+++ b/include/xcb_xrm.h
@@ -96,7 +96,7 @@ typedef struct xcb_xrm_database_t xcb_xrm_database_t;
  *     true.
  *     If XENVIRONMENT is not specified, the same is done with
  *     $HOME/.Xdefaults-$HOSTNAME, wherein $HOSTNAME is determined by
- *     gethostname(3p).
+ *     gethostname(2).
  *
  * This represents the way XGetDefault() creates the database for the most
  * part, but is not exactly the same. In particular, XGetDefault() does not

--- a/src/database.c
+++ b/src/database.c
@@ -53,7 +53,7 @@ void xcb_xrm_database_put(xcb_xrm_database_t *database, xcb_xrm_entry_t *entry, 
  *     true.
  *     If XENVIRONMENT is not specified, the same is done with
  *     $HOME/.Xdefaults-$HOSTNAME, wherein $HOSTNAME is determined by
- *     gethostname(3p).
+ *     gethostname(2).
  *
  * This represents the way XGetDefault() creates the database for the most
  * part, but is not exactly the same. In particular, XGetDefault() does not


### PR DESCRIPTION
3p is either 3posix, 3perl or 3pm. On my machine, I only have an entry of gethostname in category 2, so I assume the 3p in parens was a mistake?