### PR TITLE
Don't export symbols that are actually internal functions.

### DIFF
--- a/include/entry.h
+++ b/include/entry.h
@@ -108,32 +108,32 @@ int xcb_xrm_entry_parse(const char *str, xcb_xrm_entry_t **entry, bool resource_
  * Returns the number of components of the given entry.
  *
  */
-int xcb_xrm_entry_num_components(xcb_xrm_entry_t *entry);
+int __xcb_xrm_entry_num_components(xcb_xrm_entry_t *entry);
 
 /**
  * Compares the two entries.
  * Returns 0 if they are the same and a negative error code otherwise.
  *
  */
-int xcb_xrm_entry_compare(xcb_xrm_entry_t *first, xcb_xrm_entry_t *second);
+int __xcb_xrm_entry_compare(xcb_xrm_entry_t *first, xcb_xrm_entry_t *second);
 
 /**
  * Returns a string representation of this entry.
  *
  */
-char *xcb_xrm_entry_to_string(xcb_xrm_entry_t *entry);
+char *__xcb_xrm_entry_to_string(xcb_xrm_entry_t *entry);
 
 /**
  * Copy the entry.
  *
  */
-xcb_xrm_entry_t *xcb_xrm_entry_copy(xcb_xrm_entry_t *entry);
+xcb_xrm_entry_t *__xcb_xrm_entry_copy(xcb_xrm_entry_t *entry);
 
 /**
  * Escapes magic values.
  *
  */
-char *xcb_xrm_entry_escape_value(const char *value);
+char *__xcb_xrm_entry_escape_value(const char *value);
 
 /**
  * Frees the given entry.

--- a/include/match.h
+++ b/include/match.h
@@ -62,7 +62,7 @@ typedef struct xcb_xrm_match_t {
  * Finds the matching entry in the database given a full name / class query string.
  *
  */
-int xcb_xrm_match(xcb_xrm_database_t *database, xcb_xrm_entry_t *query_name, xcb_xrm_entry_t *query_class,
+int __xcb_xrm_match(xcb_xrm_database_t *database, xcb_xrm_entry_t *query_name, xcb_xrm_entry_t *query_class,
         xcb_xrm_resource_t *resource);
 
 #endif /* __MATCH_H__ */

--- a/src/database.c
+++ b/src/database.c
@@ -33,7 +33,7 @@
 #include "util.h"
 
 /* Forward declarations */
-void xcb_xrm_database_put(xcb_xrm_database_t *database, xcb_xrm_entry_t *entry, bool override);
+void __xcb_xrm_database_put(xcb_xrm_database_t *database, xcb_xrm_entry_t *entry, bool override);
 
 /*
  * Creates a database similarly to XGetDefault(). For typical applications,
@@ -288,7 +288,7 @@ char *xcb_xrm_database_to_string(xcb_xrm_database_t *database) {
 
     xcb_xrm_entry_t *entry;
     TAILQ_FOREACH(entry, database, entries) {
-        char *entry_str = xcb_xrm_entry_to_string(entry);
+        char *entry_str = __xcb_xrm_entry_to_string(entry);
         char *tmp;
         if (asprintf(&tmp, "%s%s\n", result == NULL ? "" : result, entry_str) < 0) {
             FREE(entry_str);
@@ -328,8 +328,8 @@ void xcb_xrm_database_combine(xcb_xrm_database_t *source_db, xcb_xrm_database_t 
         return;
 
     TAILQ_FOREACH(entry, source_db, entries) {
-        xcb_xrm_entry_t *copy = xcb_xrm_entry_copy(entry);
-        xcb_xrm_database_put(*target_db, copy, override);
+        xcb_xrm_entry_t *copy = __xcb_xrm_entry_copy(entry);
+        __xcb_xrm_database_put(*target_db, copy, override);
     }
 }
 
@@ -358,7 +358,7 @@ void xcb_xrm_database_put_resource(xcb_xrm_database_t **database, const char *re
     if (*database == NULL)
         *database = xcb_xrm_database_from_string("");
 
-    escaped = xcb_xrm_entry_escape_value(value);
+    escaped = __xcb_xrm_entry_escape_value(value);
     if (escaped == NULL)
         return;
     if (asprintf(&line, "%s: %s", resource, escaped) < 0) {
@@ -393,7 +393,7 @@ void xcb_xrm_database_put_resource_line(xcb_xrm_database_t **database, const cha
         return;
 
     if (xcb_xrm_entry_parse(line, &entry, false) == 0) {
-        xcb_xrm_database_put(*database, entry, true);
+        __xcb_xrm_database_put(*database, entry, true);
     }
 }
 
@@ -417,7 +417,7 @@ void xcb_xrm_database_free(xcb_xrm_database_t *database) {
     FREE(database);
 }
 
-void xcb_xrm_database_put(xcb_xrm_database_t *database, xcb_xrm_entry_t *entry, bool override) {
+void __xcb_xrm_database_put(xcb_xrm_database_t *database, xcb_xrm_entry_t *entry, bool override) {
     xcb_xrm_entry_t *current;
 
     if (database == NULL || entry == NULL)
@@ -428,7 +428,7 @@ void xcb_xrm_database_put(xcb_xrm_database_t *database, xcb_xrm_entry_t *entry, 
     while (current != NULL) {
         xcb_xrm_entry_t *previous = TAILQ_PREV(current, xcb_xrm_database_t, entries);
 
-        if (xcb_xrm_entry_compare(entry, current) == 0) {
+        if (__xcb_xrm_entry_compare(entry, current) == 0) {
             if (!override) {
                 xcb_xrm_entry_free(entry);
                 return;

--- a/src/entry.c
+++ b/src/entry.c
@@ -298,7 +298,7 @@ done_error:
  * Returns the number of components of the given entry.
  *
  */
-int xcb_xrm_entry_num_components(xcb_xrm_entry_t *entry) {
+int __xcb_xrm_entry_num_components(xcb_xrm_entry_t *entry) {
     int result = 0;
 
     xcb_xrm_component_t *current;
@@ -314,7 +314,7 @@ int xcb_xrm_entry_num_components(xcb_xrm_entry_t *entry) {
  * Returns 0 if they are the same and a negative error code otherwise.
  *
  */
-int xcb_xrm_entry_compare(xcb_xrm_entry_t *first, xcb_xrm_entry_t *second) {
+int __xcb_xrm_entry_compare(xcb_xrm_entry_t *first, xcb_xrm_entry_t *second) {
     xcb_xrm_component_t *comp_first = TAILQ_FIRST(&(first->components));
     xcb_xrm_component_t *comp_second = TAILQ_FIRST(&(second->components));
 
@@ -345,7 +345,7 @@ int xcb_xrm_entry_compare(xcb_xrm_entry_t *first, xcb_xrm_entry_t *second) {
  * Returns a string representation of this entry.
  *
  */
-char *xcb_xrm_entry_to_string(xcb_xrm_entry_t *entry) {
+char *__xcb_xrm_entry_to_string(xcb_xrm_entry_t *entry) {
     char *result = NULL;
     char *value_buf;
     char *escaped_value;
@@ -369,7 +369,7 @@ char *xcb_xrm_entry_to_string(xcb_xrm_entry_t *entry) {
         is_first = false;
     }
 
-    escaped_value = xcb_xrm_entry_escape_value(entry->value);
+    escaped_value = __xcb_xrm_entry_escape_value(entry->value);
     if (asprintf(&value_buf, "%s: %s", result, escaped_value) < 0) {
         FREE(escaped_value);
         FREE(result);
@@ -386,7 +386,7 @@ char *xcb_xrm_entry_to_string(xcb_xrm_entry_t *entry) {
  * Copy the entry.
  *
  */
-xcb_xrm_entry_t *xcb_xrm_entry_copy(xcb_xrm_entry_t *entry) {
+xcb_xrm_entry_t *__xcb_xrm_entry_copy(xcb_xrm_entry_t *entry) {
     xcb_xrm_entry_t *copy;
     xcb_xrm_component_t *component;
 
@@ -429,7 +429,7 @@ xcb_xrm_entry_t *xcb_xrm_entry_copy(xcb_xrm_entry_t *entry) {
  * Escapes magic values.
  *
  */
-char *xcb_xrm_entry_escape_value(const char *value) {
+char *__xcb_xrm_entry_escape_value(const char *value) {
     char *escaped;
     char *outwalk;
     int new_size = strlen(value) + 1;

--- a/src/match.c
+++ b/src/match.c
@@ -42,13 +42,13 @@ static void __match_free(xcb_xrm_match_t *match);
  * Finds the matching entry in the database given a full name / class query string.
  *
  */
-int xcb_xrm_match(xcb_xrm_database_t *database, xcb_xrm_entry_t *query_name, xcb_xrm_entry_t *query_class,
+int __xcb_xrm_match(xcb_xrm_database_t *database, xcb_xrm_entry_t *query_name, xcb_xrm_entry_t *query_class,
         xcb_xrm_resource_t *resource) {
     xcb_xrm_match_t *best_match = NULL;
     xcb_xrm_entry_t *cur_entry = TAILQ_FIRST(database);
 
     /* Let's figure out how many elements we need to store. */
-    int num = xcb_xrm_entry_num_components(query_name);
+    int num = __xcb_xrm_entry_num_components(query_name);
 
     while (cur_entry != NULL) {
         xcb_xrm_match_t *cur_match = __match_new(num);

--- a/src/resource.c
+++ b/src/resource.c
@@ -193,12 +193,12 @@ static int __resource_get(xcb_xrm_database_t *database, const char *res_name, co
      * components, so let's check that this is the case. The specification
      * backs us up here. */
     if (query_class != NULL &&
-            xcb_xrm_entry_num_components(query_name) != xcb_xrm_entry_num_components(query_class)) {
+            __xcb_xrm_entry_num_components(query_name) != __xcb_xrm_entry_num_components(query_class)) {
         result = -1;
         goto done;
     }
 
-    result = xcb_xrm_match(database, query_name, query_class, resource);
+    result = __xcb_xrm_match(database, query_name, query_class, resource);
 done:
     xcb_xrm_entry_free(query_name);
     xcb_xrm_entry_free(query_class);


### PR DESCRIPTION
This commit renames (almost, see below) all functions to have a
"__" prefix unless they are intended to be in the API. This is
necessary to avoid exporting those symbols accidentally. Thanks
to @psychon (Uli Schlachter) for noticing this.

There currently are two exceptions to this, which are
 - xcb_xrm_entry_parse
 - xcb_xrm_entry_free
We currently have to export those symbols as they are used to
unit-test the parser.

fixes #50