### PR TITLE
Autoconf xlib checks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,8 +2,6 @@ ACLOCAL_AMFLAGS = -I m4
 
 MAINTAINERCLEANFILES = ChangeLog INSTALL Makefile.in
 
-TEST_LIBS = $(shell pkg-config --libs x11 x11-xcb xcb xcb-aux)
-
 .PHONY: ChangeLog INSTALL
 
 INSTALL:
@@ -36,21 +34,22 @@ libxcb_xrm_la_LDFLAGS = -version-info 0:0:0 -no-undefined -export-symbols-regex 
 
 pkgconfig_DATA = xcb-xrm.pc
 
+if ENABLE_TESTS
+
 DIRECT_TESTS = tests/tests_parser tests/tests_match
 TESTS = $(DIRECT_TESTS) tests/tests_database_runner.sh
 check_PROGRAMS = $(DIRECT_TESTS) tests/tests_database
 
 tests_tests_parser_SOURCES = tests/tests_utils.c tests/tests_parser.c
-tests_tests_parser_CPPFLAGS = -I$(srcdir)/include/ $(XCB_CFLAGS)
-tests_tests_parser_LDADD = libxcb-xrm.la $(XCB_LIBS)
-tests_tests_parser_LDFLAGS = $(TEST_LIBS)
+tests_tests_parser_CPPFLAGS = -I$(srcdir)/include/ $(XCB_CFLAGS) $(XLIB_CFLAGS)
+tests_tests_parser_LDADD = libxcb-xrm.la $(XCB_LIBS) $(XLIB_LIBS)
 
 tests_tests_match_SOURCES = tests/tests_utils.c tests/tests_match.c
-tests_tests_match_CPPFLAGS = -I$(srcdir)/include/ $(XCB_CFLAGS)
-tests_tests_match_LDADD = libxcb-xrm.la $(XCB_LIBS)
-tests_tests_match_LDFLAGS = $(TEST_LIBS)
+tests_tests_match_CPPFLAGS = -I$(srcdir)/include/ $(XCB_CFLAGS) $(XLIB_CFLAGS)
+tests_tests_match_LDADD = libxcb-xrm.la $(XCB_LIBS) $(XLIB_LIBS)
 
 tests_tests_database_SOURCES = tests/tests_utils.c tests/tests_database.c
-tests_tests_database_CPPFLAGS = -I$(srcdir)/include/ $(XCB_CFLAGS)
-tests_tests_database_LDADD = libxcb-xrm.la $(XCB_LIBS)
-tests_tests_database_LDFLAGS = $(TEST_LIBS)
+tests_tests_database_CPPFLAGS = -I$(srcdir)/include/ $(XCB_CFLAGS) $(XLIB_CFLAGS)
+tests_tests_database_LDADD = libxcb-xrm.la $(XCB_LIBS) $(XLIB_LIBS)
+
+endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -41,15 +41,15 @@ TESTS = $(DIRECT_TESTS) tests/tests_database_runner.sh
 check_PROGRAMS = $(DIRECT_TESTS) tests/tests_database
 
 tests_tests_parser_SOURCES = tests/tests_utils.c tests/tests_parser.c
-tests_tests_parser_CPPFLAGS = -I$(srcdir)/include/ $(XCB_CFLAGS) $(XLIB_CFLAGS)
-tests_tests_parser_LDADD = libxcb-xrm.la $(XCB_LIBS) $(XLIB_LIBS)
+tests_tests_parser_CPPFLAGS = -I$(srcdir)/include/
+tests_tests_parser_LDADD = libxcb-xrm.la
 
 tests_tests_match_SOURCES = tests/tests_utils.c tests/tests_match.c
-tests_tests_match_CPPFLAGS = -I$(srcdir)/include/ $(XCB_CFLAGS) $(XLIB_CFLAGS)
-tests_tests_match_LDADD = libxcb-xrm.la $(XCB_LIBS) $(XLIB_LIBS)
+tests_tests_match_CPPFLAGS = -I$(srcdir)/include/ $(XLIB_CFLAGS)
+tests_tests_match_LDADD = libxcb-xrm.la $(XLIB_LIBS)
 
 tests_tests_database_SOURCES = tests/tests_utils.c tests/tests_database.c
-tests_tests_database_CPPFLAGS = -I$(srcdir)/include/ $(XCB_CFLAGS) $(XLIB_CFLAGS)
-tests_tests_database_LDADD = libxcb-xrm.la $(XCB_LIBS) $(XLIB_LIBS)
+tests_tests_database_CPPFLAGS = -I$(srcdir)/include/ $(XCB_CFLAGS) $(XCB_AUX_CFLAGS)
+tests_tests_database_LDADD = libxcb-xrm.la $(XCB_LIBS) $(XCB_AUX_LIBS)
 
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,18 @@ XCB_UTIL_COMMON([1.4], [1.6])
 
 PKG_CHECK_MODULES(XCB_AUX, xcb-aux)
 
+# The tests need Xlib, skip them if not found (unless --enable-tests is given)
+AC_ARG_ENABLE([tests],
+	      [AS_HELP_STRING([--disable-tests],
+			      [disable tests @<:@default=check@:>@])],
+	      [],
+	      [enable_tests=check])
+AS_CASE(["$enable_tests"],
+	[yes], [PKG_CHECK_MODULES([XLIB], [x11 x11-xcb], [enable_tests=yes])],
+	[no], [enable_tests=no],
+	[PKG_CHECK_MODULES([XLIB], [x11 x11-xcb], [enable_tests=yes], [enable_tests=no])])
+AM_CONDITIONAL(ENABLE_TESTS, [test "x$enable_tests" = "xyes"])
+
 AC_OUTPUT([Makefile
 	xcb-xrm.pc
 	xcb_xrm_intro

--- a/tests/tests_match.c
+++ b/tests/tests_match.c
@@ -31,7 +31,6 @@
 
 #include <X11/Xlib-xcb.h>
 #include <X11/Xresource.h>
-#include <xcb/xcb_aux.h>
 
 #include "tests_utils.h"
 


### PR DESCRIPTION
From the commit message:

    Build tests conditionally
    
    This moves the check for x11 and x11-xcb to configure.ac. The tests are only
    enabled if the necessary libraries are found. Additionally, this commit adds
    --enable-tests / --disable-tests flags to configure to forcefully disable tests
    and, more important, to make configure fail if the dependencies for the tests
    could not be found.
    
    I hope someone can tell me a nicer way to implement this...

(The first commit is just there since I noticed only one test actually needs xcb-aux. I still left the dependency in `Makefile.am`.)

@stapelberg Can you somehow easily test this? I guess you'd want `--enable-tests` to have configure fail if some test-dependencies could not be found.