### PR TITLE
Check for asprintf()-failures in resolve_path()

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -74,7 +74,10 @@ char *resolve_path(const char *path, const char *_base) {
     if (base == NULL)
         return NULL;
 
-    asprintf(&result, "%s/%s", base, path);
+    if (asprintf(&result, "%s/%s", base, path) < 0) {
+        FREE(base);
+        return NULL;
+    }
     FREE(base);
 
     return result;


### PR DESCRIPTION
Fixes the following warning:

warning: ignoring return value of ‘asprintf’, declared with attribute
warn_unused_result [-Wunused-result]

Signed-off-by: Uli Schlachter <uli.schlachter@informatik.uni-oldenburg.de>