### PR TITLE
Add a hard dependency on Xlib

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,8 +34,6 @@ libxcb_xrm_la_LDFLAGS = -version-info 0:0:0 -no-undefined -export-symbols-regex 
 
 pkgconfig_DATA = xcb-xrm.pc
 
-if ENABLE_TESTS
-
 DIRECT_TESTS = tests/tests_parser tests/tests_match
 TESTS = $(DIRECT_TESTS) tests/tests_database_runner.sh
 check_PROGRAMS = $(DIRECT_TESTS) tests/tests_database
@@ -51,5 +49,3 @@ tests_tests_match_LDADD = libxcb-xrm.la $(XLIB_LIBS)
 tests_tests_database_SOURCES = tests/tests_utils.c tests/tests_database.c
 tests_tests_database_CPPFLAGS = -I$(srcdir)/include/ $(XCB_CFLAGS) $(XCB_AUX_CFLAGS)
 tests_tests_database_LDADD = libxcb-xrm.la $(XCB_LIBS) $(XCB_AUX_LIBS)
-
-endif

--- a/configure.ac
+++ b/configure.ac
@@ -16,18 +16,7 @@ XCB_UTIL_M4_WITH_INCLUDE_PATH
 XCB_UTIL_COMMON([1.4], [1.6])
 
 PKG_CHECK_MODULES(XCB_AUX, xcb-aux)
-
-# The tests need Xlib, skip them if not found (unless --enable-tests is given)
-AC_ARG_ENABLE([tests],
-	      [AS_HELP_STRING([--disable-tests],
-			      [disable tests @<:@default=check@:>@])],
-	      [],
-	      [enable_tests=check])
-AS_CASE(["$enable_tests"],
-	[yes], [PKG_CHECK_MODULES([XLIB], [x11], [enable_tests=yes])],
-	[no], [enable_tests=no],
-	[PKG_CHECK_MODULES([XLIB], [x11], [enable_tests=yes], [enable_tests=no])])
-AM_CONDITIONAL(ENABLE_TESTS, [test "x$enable_tests" = "xyes"])
+PKG_CHECK_MODULES(XLIB, x11)
 
 AC_OUTPUT([Makefile
 	xcb-xrm.pc

--- a/configure.ac
+++ b/configure.ac
@@ -24,9 +24,9 @@ AC_ARG_ENABLE([tests],
 	      [],
 	      [enable_tests=check])
 AS_CASE(["$enable_tests"],
-	[yes], [PKG_CHECK_MODULES([XLIB], [x11 x11-xcb], [enable_tests=yes])],
+	[yes], [PKG_CHECK_MODULES([XLIB], [x11], [enable_tests=yes])],
 	[no], [enable_tests=no],
-	[PKG_CHECK_MODULES([XLIB], [x11 x11-xcb], [enable_tests=yes], [enable_tests=no])])
+	[PKG_CHECK_MODULES([XLIB], [x11], [enable_tests=yes], [enable_tests=no])])
 AM_CONDITIONAL(ENABLE_TESTS, [test "x$enable_tests" = "xyes"])
 
 AC_OUTPUT([Makefile

--- a/tests/tests_match.c
+++ b/tests/tests_match.c
@@ -29,7 +29,6 @@
 #include <string.h>
 #include <limits.h>
 
-#include <X11/Xlib-xcb.h>
 #include <X11/Xresource.h>
 
 #include "tests_utils.h"


### PR DESCRIPTION
This is mostly a request for comments. Does it really make sense to have this complicated magic just so that Xlib isn't a hard dependency just for the tests? Perhaps it's easier to just have a hard dependency on Xlib.

If someone disagree, I can also look more into the patch which only skip the Xlib-needing tests if Xlib is not found.