### PR TITLE
Parse entries with empty value correctly.

### DIFF
--- a/src/entry.c
+++ b/src/entry.c
@@ -255,7 +255,7 @@ process_normally:
         }
     }
 
-    if (state.chunk == CS_VALUE) {
+    if (state.chunk == CS_PRE_VALUE_WHITESPACE || state.chunk == CS_VALUE) {
         *value_walk = '\0';
         entry->value = strdup(value);
         if (entry->value == NULL)

--- a/tests/tests_match.c
+++ b/tests/tests_match.c
@@ -107,6 +107,9 @@ static int test_get_resource(void) {
     err |= check_get_resource("First: x\\\ny", "First", "", "xy", false);
     err |= check_get_resource("! First: x", "First", "", NULL, false);
     err |= check_get_resource("# First: x", "First", "", NULL, false);
+    err |= check_get_resource("First:", "First", "", "", false);
+    err |= check_get_resource("First: ", "First", "", "", false);
+    err |= check_get_resource("First: \t ", "First", "", "", false);
     /* Matching among multiple entries */
     err |= check_get_resource(
             "First: 1\n"
@@ -204,7 +207,7 @@ static int test_convert(void) {
     bool err = false;
 
     err |= check_convert_to_bool(NULL, false, -2);
-    err |= check_convert_to_bool("", false, -2);
+    err |= check_convert_to_bool("", false, -1);
     err |= check_convert_to_bool("0", false, 0);
     err |= check_convert_to_bool("1", true, 0);
     err |= check_convert_to_bool("10", true, 0);
@@ -223,7 +226,7 @@ static int test_convert(void) {
     err |= check_convert_to_bool("abc", false, -1);
 
     err |= check_convert_to_long(NULL, LONG_MIN, -2);
-    err |= check_convert_to_long("", LONG_MIN, -2);
+    err |= check_convert_to_long("", LONG_MIN, -1);
     err |= check_convert_to_long("0", 0, 0);
     err |= check_convert_to_long("1", 1, 0);
     err |= check_convert_to_long("-1", -1, 0);


### PR DESCRIPTION
This patch fixes how an entry like

    some.component:

is parsed. Previously, this would error out and ignore the entry,
but the correct behavior is to parse it and assign the empty value
to it. This is needed for applications to differentiate between a
resource not being defined and it having an empty value.

fixes #71