### PR TITLE
Update gitmodules to use https version of repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "m4"]
 	path = m4
-	url = git://anongit.freedesktop.org/xcb/util-common-m4.git
+	url = https://anongit.freedesktop.org/git/xcb/util-common-m4.git


### PR DESCRIPTION
Using the https version of the m4 repositories allows cloning in restrictive (enterprise) networks.